### PR TITLE
Add an ES module version 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,8 @@ type StringifiableArray = Array<StringifiableObject>
 type StringifiableValue = StringifiableObject | StringifiableArray | number | string | null
 type StringifiableObject = { [name: string]: StringifiableValue | undefined }
 
+// Mirror any docs changes made in index.js and index.mjs!
+
 /**
  * Stringify an object for use in a query string.
  *
@@ -9,6 +11,7 @@ type StringifiableObject = { [name: string]: StringifiableValue | undefined }
  * @param {string} prefix - When nesting, the parent key.
  *     keys in `obj` will be stringified as `prefix[key]`.
  */
+
 declare function queryStringify (obj: StringifiableObject, prefix?: string): string
 
 export = queryStringify

--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,3 @@
-/* eslint-disable no-var */
-'use strict'
-
 var has = Object.prototype.hasOwnProperty
 
 /**
@@ -12,9 +9,9 @@ var has = Object.prototype.hasOwnProperty
  * @returns {string}
  */
 
-// Mirror any changes made in index.mjs and index.d.ts!
+// Mirror any changes made in index.js and index.d.ts!
 
-module.exports = function queryStringify (obj, prefix) {
+export default function queryStringify (obj, prefix) {
   var pairs = []
   for (var key in obj) {
     if (!has.call(obj, key)) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "eslint": "^9.12.0",
+    "has-dynamic-import": "^2.1.1",
     "neostandard": "^0.12.1",
     "tape": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./index.mjs",
+      "default": "./index.js",
+      "types": "./index.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/goto-bus-stop/qs-stringify.git"

--- a/test/index.js
+++ b/test/index.js
@@ -29,3 +29,13 @@ test('stringify', function (t) {
   }), 'object[xyz]=hello&array[0]=0&array[1]=1&array[2]=2', 'should encode arrays')
   t.end()
 })
+
+var supportsModules = false
+try {
+  Function('return import("any-module")') // eslint-disable-line no-new-func
+  supportsModules = true
+} catch (_err) {}
+
+if (supportsModules) {
+  require('./module')
+}

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 'use strict'
 
 var test = require('tape')
+var hasDynamicImport = require('has-dynamic-import')
 var stringify = require('../')
 
 test('stringify', function (t) {
@@ -30,12 +31,8 @@ test('stringify', function (t) {
   t.end()
 })
 
-var supportsModules = false
-try {
-  Function('return import("any-module")') // eslint-disable-line no-new-func
-  supportsModules = true
-} catch (_err) {}
-
-if (supportsModules) {
-  require('./module')
-}
+hasDynamicImport().then(function (supportsModules) {
+  if (supportsModules) {
+    require('./module')
+  }
+})

--- a/test/module.js
+++ b/test/module.js
@@ -1,0 +1,11 @@
+/* eslint-disable no-var */
+'use strict'
+
+var test = require('tape')
+
+test('esm', function (t) {
+  return import('qs-stringify').then((m) => {
+    t.is(typeof m.default, 'function')
+    t.is(m.default({ a: 1 }), 'a=1')
+  })
+})

--- a/test/module.js
+++ b/test/module.js
@@ -4,7 +4,7 @@
 var test = require('tape')
 
 test('esm', function (t) {
-  return import('qs-stringify').then((m) => {
+  return import('qs-stringify').then(function (m) {
     t.is(typeof m.default, 'function')
     t.is(m.default({ a: 1 }), 'a=1')
   })


### PR DESCRIPTION
It's the exact same code but with `export default` instead of
`module.exports`.


This seems like the easiest way to do it (no build step). Mirroring changes will be a bit annoying but the rate of change is extremely low and I have no plans for additional features.